### PR TITLE
Add PyJWT. Add python3.10

### DIFF
--- a/.github/workflows/python-general.yml
+++ b/.github/workflows/python-general.yml
@@ -68,7 +68,7 @@ jobs:
             --layer-name "common-python-libraries" \
             --description "Common python libraries" \
             --zip-file fileb://dependencies.zip \
-            --compatible-runtimes python3.6 python3.7 python3.8 python3.9)
+            --compatible-runtimes python3.6 python3.7 python3.8 python3.9 python3.10)
           
           LAYER_VERSION=$(jq '.Version' <<< "$result")
           LAYER_VERSION_ARN=$(jq '.LayerVersionArn' <<< "$result")

--- a/python-requirements-general.txt
+++ b/python-requirements-general.txt
@@ -1,3 +1,4 @@
 requests==2.27.1
 mangum==0.17.0
 fastapi==0.96.0
+pyjwt==2.7.0


### PR DESCRIPTION
This should add the PyJWT library to the python lambda layer. Will need to be tested once the pipeline has run. I have also added a supported runtime, although it currently seems to be working with Python 3.10